### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ CI is the activity of very frequently integrating work to the trunk of version c
 
 The minimum activities required for CI are:
 
-- [Trunk-based development](#trunk-based-development)
+- [Trunk-based development](https://trunkbaseddevelopment.com/)
 - Work integrates to the trunk at a minimum daily
 - Work has automated testing before merge to trunk
 - Work is tested with other work automatically on merge
@@ -47,7 +47,9 @@ The minimum activities required for CI are:
 
 ## Trunk-based Development
 
-Trunk-based development is the safest branching pattern. It prevents lost work, the risk of corruption that comes from merge conflict resolution, and also reduces movement waste that increases batch size.
+[Trunk-based development](https://trunkbaseddevelopment.com/) is the branching pattern required to meet the definition
+of CI. It prevents lost work, the risk of corruption that comes from merge conflict resolution, and also reduces movement
+waste that increases batch size.
 
 - The minimum activities required for TBD are:
   - All changes integrate into the trunk

--- a/references.md
+++ b/references.md
@@ -17,6 +17,3 @@ are specific to solving the problem if "why can't we go to production today?"
 | [Trunk-Based Development And Branch Abstraction](https://leanpub.com/trunk-based-development)                                                       | Book    | Paul Hammant                            |
 | [Real Example of a Deployment Pipeline in the Fintech Industry](https://youtu.be/bHKHdp4H-8w)                                                       | Video    | Dave Farley                         |
 | [Continuous Delivery: Anatomy of the Deployment Pipeline](https://www.informit.com/articles/article.aspx?p=1621865)                                                       | Website    | Dave Farley                         |
-| [Devops Pipeline](https://www.atlassian.com/devops/devops-tools/devops-pipeline)                                                       | Website    | Tom Hall                          |
-
-


### PR DESCRIPTION
Add link to TrunkBasedDevelopment.com
Remove Atlassian's "DevOps Pipeline" reference due to non-standard language that confuses CD with DevOps