### PR TITLE
content and design udpates 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 -- Accelerate
 
-We, [the undersigned](#signatories), believe that a minimal definition of continuous delivery (CD)  is required to improve the flow of delivery. While our
-contexts may be different, there are universal practices. By defining them we can:
+We, [the undersigned](#signatories), believe that a minimal definition of continuous delivery (CD)  is required to improve the flow of delivery. While our contexts may be different, there are universal practices. By defining them we can:
 
 - Introduce new practitioners in a consistent way
 - Discuss engineering practices that comprise CD
@@ -58,13 +57,17 @@ waste that increases batch size.
     - The re-integrate to the trunk
     - They are short-lived and removed after the merge
 
----
+## Beyond the Minimums
 
-## [Beyond the Minimums](./references.md)
+Minimum CD is not the first step in a maturity model. However, it is still the bare minimum upon which many more practices could be built as appropriate to your context.  To aid your journey in going beyond Minimum CD, we maintain a list of resources that focus on Continuous Delivery which we have found very useful in our own journeys. 
 
-## [Why did we build this?](./faq.md)
+These contain the basics, but also the knowledge needed to become an "Elite" CD organization. They are specific to solving the problem of "why can't we go to production today?"
 
----
+[Read the list](./references.md).
+
+## Why did we build this?
+
+For more background on Minimum CD and answers to other common questions, please [read the FAQs](./faq.md).
 
 ## Signatories
 

--- a/references.md
+++ b/references.md
@@ -1,9 +1,5 @@
 # Recommended Resources
 
-The following are resources that focus on Continuous Delivery that we have found very useful in our own journeys. They
-contain the basics, but also the knowledge needed to become an "Elite" CD organization. These
-are specific to solving the problem if "why can't we go to production today?" 
-
 | Reference                                                                                                                                           | Type    | Source                                  |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------|---------|-----------------------------------------|
 | [Continuous Delivery Pipelines](https://leanpub.com/cd-pipelines)                                                                                   | Book    | Dave Farley                             |
@@ -15,5 +11,5 @@ are specific to solving the problem if "why can't we go to production today?"
 | [Refactoring Databases: Evolutionary Database Design](<https://databaserefactoring.com/>)                                                           | Book    | Scott Ambler, Pramod Sadalage           |
 | [Trunk-based Development](https://trunkbaseddevelopment.com/)                                                                                       | Website | Paul Hammant                            |
 | [Trunk-Based Development And Branch Abstraction](https://leanpub.com/trunk-based-development)                                                       | Book    | Paul Hammant                            |
-| [Real Example of a Deployment Pipeline in the Fintech Industry](https://youtu.be/bHKHdp4H-8w)                                                       | Video    | Dave Farley                         |
-| [Continuous Delivery: Anatomy of the Deployment Pipeline](https://www.informit.com/articles/article.aspx?p=1621865)                                                       | Website    | Dave Farley                         |
+| [Real Example of a Deployment Pipeline in the Fintech Industry](https://youtu.be/bHKHdp4H-8w)                                                       | Video   | Dave Farley                             |
+| [Continuous Delivery: Anatomy of the Deployment Pipeline](https://www.informit.com/articles/article.aspx?p=1621865)                                 | Website | Dave Farley                             |


### PR DESCRIPTION
I made some content and design updates to make the references and FAQs more easily discoverable as well as make the home page's content flow a little better - those horizontal rules seemed to break it up too much (except the one right before the first Continuous Delivery heading - I think that one's appropriate).  

Mainly made these changes because I didn't realize the "beyond the minimums" and "why did we build this?" headings were links - that's pretty uncommon from my experience.  I added some content to make that work a little better, so we should prob take a gander at that and see if we think it's copacetic.  

Fixed some whitespace and typos as well.