### PR TITLE
Update minimum viable TBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ waste that increases batch size.
 
 - The minimum activities required for TBD are:
   - All changes integrate into the trunk
+  - Size of changes are kept to a minimum
   - If branches from the trunk are used:
     - They originate from the trunk
     - They re-integrate to the trunk
-    - They are short-lived and removed after the merge
 
 ## Beyond the Minimums
 


### PR DESCRIPTION
Remove `They are short-lived and removed after the merge` from working with branches—inserted point on the size of changes.

1. Not `removing branches after merge` does not create an unacceptable risk to the end-user.
2. Size of changes applies regardless of whether branching is used.