### PR TITLE
Fix malformed link to youtube video

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -56,4 +56,4 @@ so important.
 
 ## What do we mean by definition of deployable?
 
-For every organization there should be non-negotiables in place for delivery. These may included security, compliance, stability, responsiveness, etc. The pipeline should be that final word for this. See Dave Farley's video [Real Example of a Deployment Pipeline in the Fintech Industry]([Real Example of a Deployment Pipeline in the Fintech Industry](https://www.youtube.com/watch?v=bHKHdp4H-8w))
+For every organization there should be non-negotiables in place for delivery. These may included security, compliance, stability, responsiveness, etc. The pipeline should be that final word for this. See Dave Farley's video [Real Example of a Deployment Pipeline in the Fintech Industry](https://www.youtube.com/watch?v=bHKHdp4H-8w))


### PR DESCRIPTION
# Description

Only a fix to a malformed link. No signature or content changes.

The link was rendered in html with the url=`https://minimumcd.org/[Real%20Example%20of%20a%20Deployment%20Pipeline%20in%20the%20Fintech%20Industry](https://www.youtube.com/watch?v=bHKHdp4H-8w)`.

Corrects so it is a direct link to youtube.com with the existing text.

Thanks!
