### PR TITLE
Add reference to the actual minimumcd.org website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a community project to define the minimum set of practices that give the expected improvements to outcomes, quality of life, and organizational structure that come with continuous delivery.
 
+The website for this project, contained in this repo, is currently hosted at [minimumcd.org](https://minimumcd.org/minimumcd/)
+
 ## Contributing
 
 Please see the [contribution](CONTRIBUTING.md) page for adding signatures or suggesting improvements.


### PR DESCRIPTION
# Description

It is reasonably easy to navigate from the website to this GH repo through the GitHub link at the top of the page, but for people finding this repo first, there is no reference at all to the actual website, apart from in the CNAME and config files.

This PR just adds a sentence to the project README with a link to https://minimumcd.org/minimumcd/

## Type of change

Addition to README file