### PR TITLE
set faq draft status to false

### DIFF
--- a/content/FAQ/_index.md
+++ b/content/FAQ/_index.md
@@ -2,7 +2,7 @@
 title: Frequent Questions
 description: FAQ
 weight: 5
-draft: true
+draft: false
 ---
 
 ## Why does this exist?


### PR DESCRIPTION
# Description

At some point draft was set to true and never set back to false. This broke some of the links

## Type of change

bug fix
