### PR TITLE
Propose Update to Manifesto - 'Add link to John Allspaw and Paul Hammond's talk on how Flickr used trunk-based development with feature toggles'

### DIFF
--- a/content/ExperienceReports/_index.md
+++ b/content/ExperienceReports/_index.md
@@ -15,6 +15,7 @@ It's true, some people still think CD is just tools. Here are some reports from 
 - [Claire Liguori on trunk-based development at Amazon](https://twitter.com/clare_liguori/status/1275128831821504512)
 - [Ken Mugrage on trunk-based development as part of modern Continuous Delivery](https://www.youtube.com/watch?v=w008iz_UwDk&t=1151s)
 - [Jez Humble on the three-year-long transition to CI/trunk-based development in the HP LaserJet firmware team](https://www.youtube.com/watch?v=2zYxWEZ0gYg&t=1682s)
+- [John Allspaw and Paul Hammond on trunk-based development with feature toggles at Flickr (in 2009)](https://www.youtube.com/watch?v=LdOe18KhtT4&t=972s)
 
 ## MinimumCD in the Media
 


### PR DESCRIPTION
# Description

Adding Fickr's testimony of trunk-based development + feature toggles. The video is quite old (2009), it's a description of embryonic DevOps and contains a lot of information about a successful software delivery model.

I'm aware that that page already contains a good number of resources about tbd, so feel free to reject my PR :) I won't be offended :D 

## Type of change

- [X] Propose Update to Manifesto
