### PR TITLE
avoid email to be exposed

### DIFF
--- a/data/names/contributors.yml
+++ b/data/names/contributors.yml
@@ -93,7 +93,7 @@ list:
     contact: https://www.linkedin.com/in/andrealaforgia
   - fName: Jean-François
     lName: Lépine
-    contact: mailto:lepinejeanfrancois@gmail.com
+    contact: https://www.linkedin.com/in/jean-fran%C3%A7ois-l%C3%A9pine-6a122726
   - fName: Jesse
     lName: Lin
     contact: https://www.linkedin.com/in/jesse-lin


### PR DESCRIPTION
# Description

This is a minor contribution : I think my email has been taken from my Github account. I prefer to avoid exposing it too much, if possible. :)

## Type of change

Please delete the option that is not relevant.

- [ ] Minor change in contributors file

Thanks !
