### PR TITLE
Vertically center header elements

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,7 @@ color_second = "#b30000"
 disableSearch = false # default is false
 disableNavChevron = false # set true to hide next/prev chevron, default is false
 menushortcutsnewtab = false # set true to open shortcuts links to a new tab/window
+custom_css = ["css/style.css"]
 
 editURL = "https://github.com/Minimum-CD/cd-manifesto/blob/master/content/"
 enableGitInfo = true

--- a/data/names/contributors.yml
+++ b/data/names/contributors.yml
@@ -133,6 +133,6 @@ list:
   - fName: Sean
     lName: Poulter
     contact: https://ca.linkedin.com/in/seanpoulter
-  - fName: Luiz
-    lName: Esmiralha
-    contact: https://www.linkedin.com/in/luizesmiralha
+  - fName: Doug
+    lName: Barrett
+    contact: https://dkb.nz/

--- a/layouts/partials/body-header.html
+++ b/layouts/partials/body-header.html
@@ -1,12 +1,12 @@
 <div>
     {{if not (in .Params.hide "nav")}}
     <div class="burger {{.Params.layout }}">
-        <a href="javascript:void(0);" style="font-size:15px;" onclick="$('article > aside').toggleClass('responsive')">&#9776;</a>
+        <a href="javascript:void(0);" onclick="$('article > aside').toggleClass('responsive')">&#9776;</a>
     </div>
     {{end}}
 
-    <div height="100px">
-    {{- $defaultheader := printf "<a class='baselink' href='%s'><img src='%s' alt='Site logo' height='100px'> %s</a>" .Site.BaseURL .Site.Params.logo .Site.Title -}}
+    <div>
+    {{- $defaultheader := printf "<a class='baselink' href='%s'><img src='%s' alt='Site logo'> %s</a>" .Site.BaseURL .Site.Params.logo .Site.Title -}}
     {{- partial "_mdinclude.html" (dict "name" "header" "context" . "tip" $defaultheader ) -}}
     </div>
 
@@ -21,5 +21,4 @@
         {{- end}}
     </nav>
     {{- end}}
-
 </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,3 @@
+{{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+{{- end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,11 @@
+body header, header a, header nav {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+@media (max-width: 936px) {
+    body header div.burger {
+      display: flex;
+    }
+}


### PR DESCRIPTION
# Description

Fix vertical alignment of header elements
- Add custom css to head
- Use flexbox for responsive spacing

Fixes #283

Unfortunately the theme has hard-coded 45px as the header height, which is used for calculating viewports in other areas. Would need to change upstream if we'd like a bigger header.

![Screenshot from 2023-06-24 17-18-26](https://github.com/Minimum-CD/cd-manifesto/assets/42837121/0f804892-e4b0-4dbe-ba1f-1f659e334f6c)
![Screenshot from 2023-06-24 17-18-01](https://github.com/Minimum-CD/cd-manifesto/assets/42837121/a9744ece-1984-467a-9097-ef69c1dabcb5)

