### PR TITLE
Fix github star button.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,7 @@
 {{ range .Site.Params.custom_css -}}
     <link rel="stylesheet" href="{{ . | absURL }}">
 {{- end }}
+
+{{ range .Site.Params.custom_js -}}
+    <script async defer src="{{ . | absURL }}"></script>
+{{- end }}


### PR DESCRIPTION
# Description

Add custom_js to `head.html`. This will show the github star button as expected.
