### PR TITLE
Improve accessibility by not skipping a heading level for contributor/signature counts

### DIFF
--- a/layouts/shortcodes/contributors.html
+++ b/layouts/shortcodes/contributors.html
@@ -7,7 +7,7 @@
 {{ end }}
 {{ $sortedNames = sort $sortedNames ".lastName" }}
 <div>
-    <h4>({{ len $sortedNames }})</h4>
+    <h3>({{ len $sortedNames }})</h3>
     {{ range $index, $element := $sortedNames }}
         {{ if gt $index 0 }}&bull;{{ end }}
         {{ if .contact }}

--- a/layouts/shortcodes/signatures.html
+++ b/layouts/shortcodes/signatures.html
@@ -1,6 +1,6 @@
 {{ $names := .Site.Data.names.signatures.list }}
 <div>
-    <h4>({{ len $names }})</h4>
+    <h3>({{ len $names }})</h3>
     {{ range $index, $element := $names }}
         {{ if gt $index 0 }}&bull;{{ end }}
         {{ if .contact }}


### PR DESCRIPTION
# Description

This fixes a minor accessibility issue with skipped headings on the main page: The heading level jumps from level 2 straight to level 4 in the contributor and signature lists. This goes against accessibility best practices, for example according to W3C:

> Skipping heading ranks can be confusing and should be avoided where possible: Make sure that a \<h2\> is not followed directly by an \<h4\>, for example.
> <sup>https://www.w3.org/WAI/tutorials/page-structure/headings/#heading-ranks</sup>

The fix is to simply use heading level 3 (instead of level 4) for the contributor/signature counts.

After this change, the contributor and signature count font becomes slightly bigger. But it doesn’t look too bad, at least in my opinion:

**Before:**
<img width="254" alt="image" src="https://github.com/Minimum-CD/cd-manifesto/assets/183207/b5b2e568-9805-4e17-8b9a-ae96fd392860">
**After:**
<img width="254" alt="image" src="https://github.com/Minimum-CD/cd-manifesto/assets/183207/f8c044ec-1e78-4ade-b9c3-41574781ba58">

## Type of change

This only changes the presentation of the contributor/signature counts. There are no changes to the manifesto text itself.
