### PR TITLE
 downgrade/pin CI pipeline hugo version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.122.0'
           extended: true
 
       - name: Run Tests


### PR DESCRIPTION
## Description

As I wrote in [another open PR](https://github.com/Minimum-CD/cd-manifesto/pull/367#issuecomment-1964762136), the latest version of Hugo is causing build errors, which block [two open PRs](https://github.com/Minimum-CD/cd-manifesto/pulls).

The [last successful build](https://github.com/Minimum-CD/cd-manifesto/actions/runs/7791777201/job/21248530758) used Hugo version [v0.122.0](https://github.com/gohugoio/hugo/releases/tag/v0.122.0) (released 2024-01-26). Reverting to that version of Hugo fixes the build. This is a temporary solution.

The latest version of Hugo is [v0.123.7](https://github.com/gohugoio/hugo/releases/tag/v0.123.7).

## Beyond this PR

Between v0.122.0 and v0.123.7, there must have been a change in Hugo that somehow led to the render errors encountered in the recent builds ([example failing build, using Hugo v0.123.3](https://github.com/Minimum-CD/cd-manifesto/actions/runs/8053024221/job/21994431946)). I would use `cd-manifesto/.github/workflows/ci.yml` to Iterate through all the subsequent versions of Hugo to find the specific version of Hugo where the errors started.

Maybe someone who knows more about Hugo has a faster way to understand the errors.