### PR TITLE
Fix typo in signatures.yml for Daniel Kovacs

### DIFF
--- a/data/names/signatures.yml
+++ b/data/names/signatures.yml
@@ -398,4 +398,4 @@ list:
   - name: Ryan Whitwell
     contact: https://www.linkedin.com/in/ryanwhitwell/
   - name: Daniel Kovacs
-    contact: https://www.linedkin.com/in/dkovacs1/
+    contact: https://www.linkedin.com/in/dkovacs1/


### PR DESCRIPTION
Typo fixed in the linkedin url

# Description

LinkedIn was mistyped in the contact link, this commit replaces it to the proper url. Found out after clicking on the name on the actual minimumCD page.

Fixes # (issue)

## Type of change


- [ ] Signature (please update title to "Signature 'your name'")

