### PR TITLE
chore: add *.pid to codegraph gitignore

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -14,6 +14,4 @@ cache/
 
 # Hook markers
 .dirty
-
-# Daemon PID
-daemon.pid
+*.pid


### PR DESCRIPTION
Replaces the `daemon.pid` entry in `.codegraph/.gitignore` with a `*.pid` glob so any codegraph PID file is ignored.

Direct push to `master` is blocked by branch protection (requires PR + `build` status check), so this goes through a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)